### PR TITLE
Removed node.js from project dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     }
   ],
   "dependencies": {
-    "node": "^16.4.0"
   },
   "devDependencies": {
     "cordova": "^11.0.0"


### PR DESCRIPTION
Removed node.js from project dependencies, because it conflicts with locally installed.